### PR TITLE
Streamline file watchers in development

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ To get started:
 npm install
 # To generate static CSS and images/ in dist/ :
 npm run build:webpack
+# To generate a static Storybook in storybook/ :
+npm run build:storybook
 # To run the demonstration site locally on http://localhost:9001/ :
 npm start
 ```

--- a/package.json
+++ b/package.json
@@ -16,10 +16,9 @@
     "lint:css": "stylelint './**/*.css'",
     "lint:js": "eslint --color .",
     "watch": "npm-run-all --parallel watch:*",
-    "watch:build": "onchange '**/*.css' -e 'vendor/**' -vip -- npm run build",
     "watch:lint": "npm-run-all --parallel watch:lint:*",
-    "watch:lint:css": "onchange '**/*.css' -e 'vendor/*' -vip -- npm run lint:css",
-    "watch:lint:js": "onchange '**/*.js' -e 'node_modules/*' -vip -- npm run lint:js"
+    "watch:lint:css": "onchange '**/*.css' -e 'dist/**' -e 'storybook/**' -vi -- npm run lint:css",
+    "watch:lint:js": "onchange '**/*.js' -e 'dist/**' -e 'storybook/**' -vi -- npm run lint:js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Stop doing a full static build on every file change

- Exclude files in dist/ and storybook/ from watchers

- Stop polling in file watchers, seems to cause high CPU

Fixes #50