### PR TITLE
Prevent CircleCI build failures on gh-pages branch

### DIFF
--- a/bin/deploy-gh-master.sh
+++ b/bin/deploy-gh-master.sh
@@ -16,5 +16,6 @@ zip -r deploy/dist.zip dist
 ./node_modules/.bin/gh-pages \
   --silent \
   --dist deploy \
+  --message 'Storybook deploy [skip ci]' \
   --user 'GH Deploy <lorchard@mozilla.com>' \
   --repo https://$GH_TOKEN@github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME.git


### PR DESCRIPTION
Turns out there's no CircleCI config in the gh-branch. We don't want any tests there, but missing the config means CircleCI doesn't know that. [Adding `[skip ci]` to the commit messages should help.](https://circleci.com/docs/2.0/skip-build/#skipping-a-build)