### PR TITLE
Simplify the comments posted for gh-pages deployment

### DIFF
--- a/bin/deploy-gh-pages.sh
+++ b/bin/deploy-gh-pages.sh
@@ -73,7 +73,7 @@ EOF
   curl \
     -H'Content-Type: application/json' \
     -H"Authorization: token $GH_TOKEN" \
-    --data "{\"body\":\"# GitHub Pages Deployment\\nPull Request:\\n$STORYBOOK_PR_URL\\nBranch:\\n$BRANCH_URL\\nStorybook:\\n$DEPLOY_URL\\nBuild:\\n${DEPLOY_URL}dist.zip\"}" \
+    --data "{\"body\":\"# GitHub Pages Deployment\\nStorybook:\\n$DEPLOY_URL\\nBuild:\\n${DEPLOY_URL}dist.zip\"}" \
     https://api.github.com/repos/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}/issues/${STORYBOOK_PR_NUMBER}/comments
 fi
 


### PR DESCRIPTION
After seeing this script post comments on a few PRs, I figured it might be worth shortening the comments. Instead of listing four links, this change will list only two: The storybook build and the .zip file with the project distribution build.

The two links I'm taking out are just redirects to the storybook build, one contains the pull request number and the other has the branch name. We can probably just leave those as a kind of hidden feature for now